### PR TITLE
fix some bugs for building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # YOU MUST SET PUGIXML_HOME
 find_package(PugiXML REQUIRED)
 endif()
-include_directories(${PUGIXML_INCLUDE_DIRS})
+include_directories(${PUGIXML_INCLUDE_DIR})
 
 if(BUILD_SHARED_LIBS)
     add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES})

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ $ brew install curl pugixml
 $ git clone https://github.com/designerror/webdav-client-cpp
 $ cd webdav-client-cpp
 $ mkdir build && cd build
+# The next line is needed for building on macOS
+$ export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
 $ cmake .. && make
 $ make install
 ```


### PR DESCRIPTION
```
$ ...
$ export OPENSSL_ROOT_DIR=/usr/local/opt/openssl/
$ cmake .. && make
```

![image](https://cloud.githubusercontent.com/assets/22619865/19399832/15f9126c-925c-11e6-8f89-435936f591e7.png)

```
CMakeLists.txt contains incorrect variable PUGIXML_INCLUDE_DIRS.
You should use PUGIXML_INCLUDE_DIR which is defined in cmake/FindPugiXML.cmake.
```

![image](https://cloud.githubusercontent.com/assets/22619865/19399806/f518ac4c-925b-11e6-8f0c-d977fe0a6210.png)
