### PR TITLE
ifndef/define xxx_H and final/or_virt_destructor

### DIFF
--- a/include/webdav/client.hpp
+++ b/include/webdav/client.hpp
@@ -1,3 +1,5 @@
+#ifndef WEBDAV_CLIENT_H
+#define WEBDAV_CLIENT_H
 #pragma once
 
 #include <functional>
@@ -238,3 +240,5 @@ namespace WebDAV
 		Client() {}
 	};
 }
+
+#endif

--- a/sources/callback.hpp
+++ b/sources/callback.hpp
@@ -1,3 +1,5 @@
+#ifndef WEBDAV_CALLBACK_H
+#define WEBDAV_CALLBACK_H
 #pragma once
 
 namespace WebDAV
@@ -30,3 +32,5 @@ namespace WebDAV
 		}
 	}
 }
+
+#endif

--- a/sources/fsinfo.hpp
+++ b/sources/fsinfo.hpp
@@ -1,3 +1,5 @@
+#ifndef WEBDAV_FSINFO_H
+#define WEBDAV_FSINFO_H
 #pragma once
 
 namespace WebDAV
@@ -9,3 +11,5 @@ namespace WebDAV
 		auto size(const std::string& path_file) -> unsigned long long;
 	}
 }
+
+#endif

--- a/sources/header.cpp
+++ b/sources/header.cpp
@@ -13,13 +13,13 @@ namespace WebDAV
         }
     }
 
-    Header::~Header() noexcept
+    Header::~Header()
     {
         curl_slist_free_all((curl_slist*)this->handle);
     }
 
     void
-    Header::append(std::string item) noexcept
+    Header::append(const std::string item) noexcept
     {
         this->handle = curl_slist_append((curl_slist*)this->handle, item.c_str());
     }

--- a/sources/header.hpp
+++ b/sources/header.hpp
@@ -1,16 +1,19 @@
+#ifndef WEBDAV_HEADER_H
+#define WEBDAV_HEADER_H
 #pragma once
 
 namespace WebDAV
 {
-    class Header
+    class Header final
     {
     public:
-
         void * handle;
 
         Header(std::initializer_list<std::string> init_list) noexcept;
-        ~Header() noexcept;
+        ~Header();
 
-        void append(std::string item) noexcept;
+        void append(const std::string item) noexcept;
     };
 }
+
+#endif

--- a/sources/pugiext.hpp
+++ b/sources/pugiext.hpp
@@ -1,4 +1,7 @@
-﻿#include <pugixml.hpp>
+﻿#ifndef WEBDAV_PUGIEXT_H
+#define WEBDAV_PUGIEXT_H
+#pragma once
+#include <pugixml.hpp>
 
 namespace pugi
 {
@@ -21,3 +24,5 @@ namespace pugi
 		return writer.result;
 	}
 }
+
+#endif

--- a/sources/request.cpp
+++ b/sources/request.cpp
@@ -4,7 +4,6 @@
 
 namespace WebDAV
 {
-	
 	auto inline get(const dict_t& options, const std::string&& name) -> std::string
 	{
 		auto it = options.find(name);

--- a/sources/request.hpp
+++ b/sources/request.hpp
@@ -1,3 +1,5 @@
+#ifndef WEBDAV_REQUEST_H
+#define WEBDAV_REQUEST_H
 #pragma once
 
 #include <curl/curl.h>
@@ -39,3 +41,5 @@ namespace WebDAV
 		void * handle;
 	};
 }
+
+#endif

--- a/sources/stdafx.h
+++ b/sources/stdafx.h
@@ -1,3 +1,5 @@
+#ifndef STDAFX_H
+#define STDAFX_H
 #pragma once
 
 #include <algorithm>
@@ -11,3 +13,5 @@
 #include <vector>
 #include <thread>
 #include <string.h>
+
+#endif

--- a/sources/urn.hpp
+++ b/sources/urn.hpp
@@ -1,3 +1,5 @@
+#ifndef WEBDAV_URN_H
+#define WEBDAV_URN_H
 #pragma once
 
 namespace WebDAV
@@ -26,3 +28,5 @@ namespace WebDAV
 		Urn operator+(std::string resource_path);
 	};
 }
+
+#endif


### PR DESCRIPTION
#pragma once is a non-standard. That's why it's a good practice when you use both #pragma and #define header-guard.

You should use final specifier or virtual destructor for class Header in sources/header.hpp.

Destructor is always noexcept in C++11.